### PR TITLE
Fix opkg install step for large package selection: upstreamed

### DIFF
--- a/scripts/source-operator.sh
+++ b/scripts/source-operator.sh
@@ -59,8 +59,5 @@ source_update () {
 	git add package/kernel/mac80211/files/lib/wifi/mac80211.sh
 	git commit -m "enable cm4 wifi default"
 
-	#merge build: fix opkg install step for large package selection 
-	git cherry-pick 1854aeec4d37079690309dec3171d0864339f73a 
-
 }
 


### PR DESCRIPTION
Commit [1] is now included in upstream (openwrt-21.02 branch), no need to
apply it twice.

[1] https://github.com/openwrt/openwrt/commit/3b14ddf8d204ee59533ec76ed6018db01f77d6e7